### PR TITLE
MS-13: 도서 요청 페이지 추가

### DIFF
--- a/src/pages/RequestBook.jsx
+++ b/src/pages/RequestBook.jsx
@@ -29,8 +29,8 @@ export default function RequestBook() {
 
   const getBookInfo = async () => {
     const data = await fetchBookInfo(isbn);
-    if (data.response.docs && data.response.docs.length > 0) {
-      setBookInfo(data.response.docs[0].doc);
+    if (data.response.detail && data.response.detail.length > 0) {
+      setBookInfo(data.response.detail[0].book);
       setErrorMessage('');
     } else {
       setErrorMessage('유효하지 않은 ISBN 번호 입니다.');
@@ -39,35 +39,35 @@ export default function RequestBook() {
   };
 
   const clickSubmit = async () => {
-    if (isbn.length === 13) {
-      if (isbn.length !== 13) {
-        setErrorMessage('ISBN 번호는 13자리의 숫자만 입력 가능합니다.');
-        return;
-      }
+    if (isbn.length !== 13) {
+      setErrorMessage('ISBN 번호는 13자리의 숫자만 입력 가능합니다.');
+      return;
+    }
 
-      if (!bookInfo) {
-        setErrorMessage('도서 정보를 먼저 검색해주세요.');
-        return;
-      }
-      try {
-        const response = await createBook({
-          isbn,
-          imageUrl: bookInfo.bookImageURL,
-          name: bookInfo.bookname,
-          authors: bookInfo.authors,
-          publisher: bookInfo.publisher,
-          publicationYear: bookInfo.publication_year
-        });
-        setIsbn('');
-        setBookInfo(null);
-        setErrorMessage('');
-        alert(response.message);
-      } catch (error) {
-        const errorMsg = error.response.data.detail;
-        alert(errorMsg);
-      }
-    } else {
+    if (!bookInfo) {
       setErrorMessage('도서 정보를 먼저 검색해주세요.');
+      return;
+    }
+
+    try {
+      const response = await createBook({
+        isbn,
+        imageUrl: bookInfo.bookImageURL,
+        name: bookInfo.bookname,
+        className: bookInfo.class_nm,
+        authors: bookInfo.authors,
+        publisher: bookInfo.publisher,
+        publicationYear: bookInfo.publication_year,
+        classNo: bookInfo.class_no,
+        description: bookInfo.description
+      });
+      setIsbn('');
+      setBookInfo(null);
+      setErrorMessage('');
+      alert(response.message);
+    } catch (error) {
+      const errorMsg = error.response.data.detail;
+      alert(errorMsg);
     }
   };
 
@@ -91,6 +91,10 @@ export default function RequestBook() {
                 <dl className={'book-title'}>
                   <dt>도서명</dt>
                   <dd>{bookInfo.bookname}</dd>
+                </dl>
+                <dl className={'book-class'}>
+                  <dt>주제 분류</dt>
+                  <dd>{bookInfo.class_nm}</dd>
                 </dl>
                 <dl className={'book-author'}>
                   <dt>저자</dt>

--- a/src/pages/RequestBook.jsx
+++ b/src/pages/RequestBook.jsx
@@ -1,48 +1,114 @@
+import { useState } from 'react';
+import { useNavigate } from "react-router-dom";
 import Button from "../components/ui/Button";
+import { createBook } from "../services/book/bookAPI";
+import { fetchBookInfo } from "../services/book/booklibraryAPI";
 
-const clickSubmit = () => {
-  // console.log('제출클릭')
-  // 등록 시 수행할 js 코드 입력
-}
-
-const clickCancel = () => {
-  // console.log('제출클릭')
-  // 취소 시 수행할 js 코드 입력
-}
 export default function RequestBook() {
+  const [isbn, setIsbn] = useState('');
+  const [bookInfo, setBookInfo] = useState(null);
+  const [errorMessage, setErrorMessage] = useState('');
+  const navigate = useNavigate();
+
+  const handleInputChange = (event) => {
+    const value = event.target.value;
+    setIsbn(value);
+    if (value.length !== 13) {
+      setErrorMessage('ISBN 번호는 13자리의 숫자만 입력 가능합니다.');
+    } else {
+      setErrorMessage('');
+    }
+    setBookInfo(null);
+  };
+
+  const handleKeyPress = (event) => {
+    if (event.key === 'Enter') {
+      getBookInfo();
+    }
+  };
+
+  const getBookInfo = async () => {
+    const data = await fetchBookInfo(isbn);
+    if (data.response.docs && data.response.docs.length > 0) {
+      setBookInfo(data.response.docs[0].doc);
+      setErrorMessage('');
+    } else {
+      setErrorMessage('유효하지 않은 ISBN 번호 입니다.');
+      setBookInfo(null);
+    }
+  };
+
+  const clickSubmit = async () => {
+    if (isbn.length === 13) {
+      if (isbn.length !== 13) {
+        setErrorMessage('ISBN 번호는 13자리의 숫자만 입력 가능합니다.');
+        return;
+      }
+
+      if (!bookInfo) {
+        setErrorMessage('도서 정보를 먼저 검색해주세요.');
+        return;
+      }
+      try {
+        const response = await createBook({
+          isbn,
+          imageUrl: bookInfo.bookImageURL,
+          name: bookInfo.bookname,
+          authors: bookInfo.authors,
+          publisher: bookInfo.publisher,
+          publicationYear: bookInfo.publication_year
+        });
+        setIsbn('');
+        setBookInfo(null);
+        setErrorMessage('');
+        alert(response.message);
+      } catch (error) {
+        const errorMsg = error.response.data.detail;
+        alert(errorMsg);
+      }
+    } else {
+      setErrorMessage('도서 정보를 먼저 검색해주세요.');
+    }
+  };
+
   return (
       <div className={'request-book'}>
-        <input className={'search-isbn'} placeholder={'ISBN 번호를 입력하세요'}/>
-        <hr/>
-        <div className={'book'}>
-          <div className={'book-img'}>
-            <img src={'https://image.aladin.co.kr/product/29861/97/cover/8931466595_1.jpg'}/>
-          </div>
-          <div className={'book-info'}>
-            <dl className={'book-title'}>
-              <dt>도서명</dt>
-              <dd>(그림으로 배우는) 웹 구조 =Web technology</dd>
-            </dl>
-            <dl className={'book-class'}>
-              <dt>주제 분류</dt>
-              <dd>프로그래밍, 프로그램, 데이터</dd>
-            </dl>
-            <dl className={'book-author'}>
-              <dt>저자</dt>
-              <dd>니시무라 야스히로 저 ;유세라 역</dd>
-            </dl>
-            <dl className={'book-publisher'}>
-              <dt>출판사</dt>
-              <dd>Youngjin.com(영진닷컴)</dd>
-            </dl>
-            <dl className={'book-publication-year'}>
-              <dt>발행일</dt>
-              <dd>2022</dd>
-            </dl>
-          </div>
-        </div>
+        <input
+            className={'search-isbn'}
+            placeholder={'ISBN 번호를 입력하세요'}
+            value={isbn}
+            onChange={handleInputChange}
+            onKeyPress={handleKeyPress}
+        />
+        {errorMessage && <p style={{ color: 'red' }}>{errorMessage}</p>}
+        <hr />
+        {bookInfo && (
+            <div className={'book'}>
+              <div className={'book-img'}>
+                <img src={bookInfo.bookImageURL} alt="책 표지" />
+              </div>
+              <div className={'book-info'}>
+                <dl className={'book-title'}>
+                  <dt>도서명</dt>
+                  <dd>{bookInfo.bookname}</dd>
+                </dl>
+                <dl className={'book-author'}>
+                  <dt>저자</dt>
+                  <dd>{bookInfo.authors}</dd>
+                </dl>
+                <dl className={'book-publisher'}>
+                  <dt>출판사</dt>
+                  <dd>{bookInfo.publisher}</dd>
+                </dl>
+                <dl className={'book-publication-year'}>
+                  <dt>발행년도</dt>
+                  <dd>{bookInfo.publication_year}</dd>
+                </dl>
+              </div>
+            </div>
+        )}
         <div className={'buttons'}>
-          <Button type={'cancel'} onClick={clickCancel} className={'cancel-button'}>
+          <Button type={'cancel'} onClick={() => navigate(-1)} className={'cancel-button'}>
             취소
           </Button>
           <Button type={'submit'} onClick={clickSubmit} className={'submit-button'}>
@@ -50,5 +116,5 @@ export default function RequestBook() {
           </Button>
         </div>
       </div>
-  )
+  );
 }

--- a/src/services/book/bookAPI.js
+++ b/src/services/book/bookAPI.js
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+export const createBook = async (bookRequestDto) => {
+  try {
+    const response = await axios.post(`http://localhost:8080/api/v1/books/request`, bookRequestDto);
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/services/book/booklibraryAPI.js
+++ b/src/services/book/booklibraryAPI.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const API_URL = 'http://data4library.kr/api/srchBooks';
+const AUTH_KEY = '87ee5bbc25f7e601490254d33120aa676b1fc80490d7e4c1cb0d1b04ceb70ef5';
+
+export const fetchBookInfo = async (isbn) => {
+  try {
+    const response = await axios.get(`${API_URL}?authKey=${AUTH_KEY}&isbn13=${isbn}&format=json`);
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/services/book/booklibraryAPI.js
+++ b/src/services/book/booklibraryAPI.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = 'http://data4library.kr/api/srchBooks';
+const API_URL = 'http://data4library.kr/api/srchDtlList';
 const AUTH_KEY = '87ee5bbc25f7e601490254d33120aa676b1fc80490d7e4c1cb0d1b04ceb70ef5';
 
 export const fetchBookInfo = async (isbn) => {


### PR DESCRIPTION
# 참고
#13 

# 도서 요청 페이지

- Header
- ISBN번호 입력란
- 도서 정보
    - 도서이미지
    - 제목
    - 저자
    - 출판사
    - 발행년도
- 등록버튼
- 취소버튼(뒤로 가기)  
- Footer

# Issue

- 도서 상세 조회(구 ISBN번호 조회) API를 넣으면 DB에 존재하지 않는 도서를 throw new로 예외 발생되기 때문에 도서 상세 조회 API는 여기에 쓰지 않는게 어떤지 -> 그렇게 합시다
- DB와 중복 시 등록버튼 비활성화 & 밑에 글씨 나오게 하는것 보다 alert 창을 띄우는 게 좋아보이는데 이대로 가는게 어떤지
- 정보나루 API 도서 검색에 주제 분류가 없어서 그냥 뺐는데 이렇게 해도 괜찮은지 -> 정보나루 API 도서 상세 조회를 이용하면 된다.