### PR TITLE
JH-33: 소셜 로그인 페이지 및 컴포넌트 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,11 +28,7 @@ function App() {
           <Route path="/login/email" element={<EmailLogin/>}/>
           <Route path="/oauth2/sign-up" element={<OAuth2SignUp/>}/>
           <Route path="/sign-up" element={<SignUp/>}/>
-          <Route path="/trade/list" element={<BookTradeList />} />
-          <Route path="/trade/:tradeId" element={<BookTradeDetail />} />
-          <Route path="/trade/edit/:tradeId" element={<BookTradeEdit /> } />
-          <Route path="/trade/edit" element={<BookTradeEdit /> } />
-          <Route path="/requestBook/list" element={<RequestBookList/>} />
+          <Route path="/oauth2/login" element={<OAuth2Login/>}/>
 
           <Route path="/trade/list" element={<BookTradeList/>}/>
           <Route path="/trade/:tradeId" element={<BookTradeDetail/>}/>

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,8 @@ import SignUp from "./pages/auth/SignUp";
 import "./styles/auth.css"
 import BookTradeEdit from "./pages/trade/BookTradeEdit";
 import RequestBookList from "./pages/RequestBookList";
+import OAuth2SignUp from "./pages/auth/OAuth2SignUp";
+import OAuth2Login from "./pages/auth/OAuth2Login";
 
 function App() {
   return (
@@ -21,14 +23,22 @@ function App() {
         <Routes>
           <Route path="/" element={<Main/>}/>
           <Route path="/requestBook" element={<RequestBook/>}/>
+
           <Route path="/login" element={<Login/>}/>
           <Route path="/login/email" element={<EmailLogin/>}/>
+          <Route path="/oauth2/sign-up" element={<OAuth2SignUp/>}/>
           <Route path="/sign-up" element={<SignUp/>}/>
           <Route path="/trade/list" element={<BookTradeList />} />
           <Route path="/trade/:tradeId" element={<BookTradeDetail />} />
           <Route path="/trade/edit/:tradeId" element={<BookTradeEdit /> } />
           <Route path="/trade/edit" element={<BookTradeEdit /> } />
           <Route path="/requestBook/list" element={<RequestBookList/>} />
+
+          <Route path="/trade/list" element={<BookTradeList/>}/>
+          <Route path="/trade/:tradeId" element={<BookTradeDetail/>}/>
+          <Route path="/trade/edit/:tradeId" element={<BookTradeEdit/>}/>
+          <Route path="/trade/edit" element={<BookTradeEdit/>}/>
+          <Route path="/requestBook/list" element={<RequestBookList/>}/>
         </Routes>
         <Footer/>
       </BrowserRouter>

--- a/src/components/auth/OAuth2SignUpForm.jsx
+++ b/src/components/auth/OAuth2SignUpForm.jsx
@@ -1,0 +1,108 @@
+import {useEffect, useState} from "react";
+import InputField from "./InputField";
+import Button from "../ui/Button";
+import {useDaumPostcodePopup} from 'react-daum-postcode'
+import {requestDuplicate, requestOauthSignUp, requestSignUp} from "../../services/auth/authAPI";
+import {buttonValid, handleInputChange, initialInputFields} from "../../services/auth/utils";
+import {useLocation, useNavigate} from "react-router-dom";
+import {testRegExp} from "../../services/auth/regexp";
+
+export default function OAuth2SignUpForm() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const open = useDaumPostcodePopup();
+  let [fields, setFields] = useState({
+    nickname: initialInputFields("nickname"),
+    address: initialInputFields("address"),
+    phone: initialInputFields("phone"),
+  })
+  let [isFormValid, setIsFormValid] = useState(false)
+  useEffect(() => {
+    const isValid = buttonValid(fields)
+    setIsFormValid(isValid);
+  }, [fields]);
+  const isConfirmation = (field) => {
+    return field.disabled || field.value === "" || !field.valid;
+  }
+
+  const submitSignUpForm = async (e) => {
+    e.preventDefault()
+    try {
+      let accessToken = new URLSearchParams(location.search).get("token");
+      let result = await requestOauthSignUp(fields, accessToken);
+      alert(result);
+      navigate("/login")
+    } catch (error) {
+      let details = error.response.data.details;
+      Object.values(details).forEach((key, value) => {
+        updateFields(key, {valid: false, value: value})
+      })
+    }
+  }
+  const handleNicknameCheck = async () => {
+    try {
+      let result = await requestDuplicate(fields.nickname);
+      if (window.confirm(result)) {
+        updateFields("nickname", {disabled: true})
+      }
+    } catch (error) {
+      updateFields("nickname", {valid: false, caption: error.response.data.details.nickname, duplicate: true})
+    }
+  }
+  const handleAddress = () => {
+    open({
+      onComplete: (data) => {
+        let valid = testRegExp("address", data.address);
+        updateFields("address", {value: data.address, valid: testRegExp("address", data.address)})
+      }
+    })
+  }
+  const updateFields = (fieldName, keyValue) => {
+    setFields({
+      ...fields,
+      [fieldName]: {
+        ...fields[fieldName],
+        ...keyValue
+      }
+    })
+  }
+
+  return (
+      <div className="sign-up">
+        <form onSubmit={submitSignUpForm} className="sign-up">
+          <InputField field={fields.nickname}
+                      value={fields.nickname.value}
+                      eventHandler={(value) => handleInputChange(fields.nickname, setFields, value)}
+                      valid={fields.nickname.valid}
+                      button={
+                        <Button type="button" className="checking-verification"
+                                disabled={isConfirmation(fields.nickname)}
+                                onClick={handleNicknameCheck}>
+                          중복확인
+                        </Button>
+                      }>
+            <p className="invalid-caption">{fields.nickname.duplicate ? fields.nickname.caption
+                : "영문, 유효한 한글, 숫자를 이용하여 3자 이상 20자 이하로 입력해주세요."}</p>
+          </InputField>
+          <InputField field={fields.address}
+                      value={fields.address.value}
+                      valid={fields.address.valid}
+                      button={
+                        <Button type="button" className="finding-address" onClick={handleAddress}>
+                          주소 찾기
+                        </Button>
+                      }
+                      onClick={handleAddress}>
+            <p className="invalid-caption">현재는 서울시만 등록가능합니다.</p>
+          </InputField>
+          <InputField field={fields.phone}
+                      value={fields.phone.value}
+                      eventHandler={(value) => handleInputChange(fields.phone, setFields, value)}
+                      valid={fields.phone.valid}>
+            <p className="invalid-caption">유효하지 않은 휴대폰 번호 형식입니다.</p>
+          </InputField>
+          <Button type="submit" className="auth-button" disabled={!isFormValid}>가입하기</Button>
+        </form>
+      </div>
+  )
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import './styles/common.css'
 import './styles/request-book.css'
 import './styles/book-trade.css'
 import './styles/book-search.css'
+import './styles/login-type-b.css'
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -6,19 +6,61 @@ export default function Login() {
   return (<section className="sign-up-main">
     <Title>간편하게 로그인 하세요.</Title>
     <div>
-      <Link to="">
-        <Button className="auth-button">카카오 계정으로 계속하기</Button>
-      </Link>
+      회원이 되어 회원 간 대출 서비스를 이용해 보세요.
     </div>
-    <div>
-      <Link to="">
-        <Button className="auth-button">구글 계정으로 계속하기</Button>
-      </Link>
-    </div>
-    <div>
-      <Link to="/login/email">
-        <Button className="auth-button">이메일로 계속하기</Button>
-      </Link>
+    <div className="login-buttons-section">
+      <div>
+        <a href="http://localhost:8080/oauth2/authorization/kakao" style={{textDecoration: "none"}}>
+          <Button className="kakao-login-button">
+            <span className="login-svg">
+              <svg viewBox="0 0 21 20" width="21" height="20" fill="none" className="login-svg">
+                <path fillRule="evenodd" clipRule="evenodd"
+                      d="M10.5 2.62891C6.16282 2.62891 2.64282 5.36319 2.64282 8.72605C2.64282 10.8239 4.00211 12.6546 6.07639 13.7703L5.20425 16.9682C5.1878 17.0318 5.19118 17.0989 5.21396 17.1605C5.23673 17.2222 5.27781 17.2754 5.33167 17.313C5.38554 17.3506 5.44962 17.3709 5.51532 17.371C5.58102 17.3712 5.6452 17.3513 5.69925 17.3139L9.51782 14.776C9.83997 14.776 10.17 14.8311 10.5 14.8311C14.8371 14.8311 18.3571 12.0968 18.3571 8.72605C18.3571 5.35534 14.8371 2.62891 10.5 2.62891Z"
+                      fill="#181600">
+                </path>
+              </svg>
+            </span>
+            <p className="kakao-login-button-text">카카오 계정으로 계속하기</p>
+          </Button>
+        </a>
+      </div>
+      <div>
+        <a href="http://localhost:8080/oauth2/authorization/google" style={{textDecoration: "none"}}>
+          <Button className="google-login-button">
+            <span className="login-svg">
+              <svg viewBox="0 0 16 16" width="16" height="16" fill="none" className="login-svg">
+                <g id="Group">
+                  <path id="Vector" fillRule="evenodd" clipRule="evenodd"
+                        d="M15.4057 8.17566C15.4057 7.6288 15.3569 7.10251 15.2651 6.59766H8V9.58137H12.152C11.9729 10.5457 11.4294 11.3634 10.6126 11.9102V13.8457H13.1051C14.564 12.5025 15.4057 10.5251 15.4057 8.17566Z"
+                        fill="#3D82F0">
+
+                  </path>
+                  <path id="Vector_2" fillRule="evenodd" clipRule="evenodd"
+                        d="M8.0002 15.7146C10.0831 15.7146 11.8291 15.0238 13.1053 13.8461L10.6128 11.9098C9.92192 12.3726 9.0382 12.6461 8.0002 12.6461C5.99106 12.6461 4.29049 11.2892 3.68363 9.46606H1.1062V11.4649C2.37563 13.9858 4.98477 15.7146 8.0002 15.7146Z"
+                        fill="#31A752">
+                  </path>
+                  <path id="Vector_3" fillRule="evenodd" clipRule="evenodd"
+                        d="M3.68348 9.46593C3.5292 9.00307 3.44177 8.5085 3.44177 8.00022C3.44177 7.49193 3.5292 6.99736 3.68348 6.5345V4.53564H1.10605C0.584052 5.57707 0.285767 6.75564 0.285767 8.00022C0.285767 9.24479 0.584052 10.4234 1.10605 11.4648L3.68348 9.46593Z"
+                        fill="#F9BA00">
+                  </path>
+                  <path id="Vector_4" fillRule="evenodd" clipRule="evenodd"
+                        d="M8.0002 3.35422C9.13249 3.35422 10.1499 3.74336 10.9488 4.50793L13.1619 2.29564C11.8256 1.05022 10.0796 0.285645 8.0002 0.285645C4.98477 0.285645 2.37563 2.0145 1.1062 4.53622L3.68363 6.53422C4.29049 4.71107 5.99106 3.35422 8.0002 3.35422Z"
+                        fill="#E64234">
+                  </path>
+                </g>
+              </svg>
+            </span>
+            <p className="login-button-text">구글 계정으로 계속하기</p>
+          </Button>
+        </a>
+      </div>
+      <div className="field">
+        <Link to="/login/email" style={{textDecoration: "none"}}>
+          <Button className="email-login-button">
+            <p className="login-button-text">이메일로 계속하기</p>
+          </Button>
+        </Link>
+      </div>
     </div>
   </section>);
 }

--- a/src/pages/auth/OAuth2Login.jsx
+++ b/src/pages/auth/OAuth2Login.jsx
@@ -1,0 +1,22 @@
+import {useEffect} from "react";
+import {requestAccessTokenForOAuth2Login, requestOauthSignUp} from "../../services/auth/authAPI";
+import {useNavigate} from "react-router-dom";
+
+export default function OAuth2Login() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    const awaitToken = async () => {
+      try {
+        let result =await requestAccessTokenForOAuth2Login();
+        console.log(result);
+        localStorage.setItem("accessToken", result.data.accessToken);
+        navigate("/")
+      } catch (error) {
+        console.log(error)
+      }
+    }
+    awaitToken()
+  }, []);
+
+  return <div>로그인 중입니다 잠시만 기다려주세요.</div>
+}

--- a/src/pages/auth/OAuth2SignUp.jsx
+++ b/src/pages/auth/OAuth2SignUp.jsx
@@ -1,0 +1,13 @@
+import Back from "../../components/auth/Back";
+import Title from "../../components/ui/Title";
+import OAuth2SignUpForm from "../../components/auth/OAuth2SignUpForm";
+
+export default function OAuth2SignUp() {
+  return (
+      <section className="sign-up-main">
+        <Back/>
+        <Title>추가 정보 입력</Title>
+        <OAuth2SignUpForm/>
+      </section>
+  )
+}

--- a/src/services/auth/authAPI.js
+++ b/src/services/auth/authAPI.js
@@ -2,6 +2,8 @@ import axios from "axios";
 
 const BASE_URL = "http://localhost:8080"
 const SIGN_UP = "/api/v1/signup"
+const OAUTH2_SIGN_UP = "/api/v1/oauth2/signup"
+const OAUTH2_ACCESS_TOKEN = "/api/v1/oauth2/accessToken"
 const DUPLICATE = "/duplicate"
 const AUTH_EMAIL = "/email"
 const VERIFICATION_CODE = "/verification-code";
@@ -58,6 +60,23 @@ export const requestSignUp = async (fields) => {
     throw error
   }
 }
+export const requestOauthSignUp = async (fields, accessToken) => {
+  let data = {
+    nickname: fields.nickname["value"],
+    address: fields.address["value"],
+    phone: fields.phone["value"]
+  }
+  try {
+    const response = await axios.post(BASE_URL + OAUTH2_SIGN_UP, data, {
+      headers: {
+        Authorization: "Bearer " + accessToken
+      }
+    });
+    return response.data.message
+  } catch (error) {
+    throw error
+  }
+}
 
 export const requestLogin = async (fields) => {
   let data = {
@@ -65,7 +84,7 @@ export const requestLogin = async (fields) => {
     password: fields.password.value
   }
   try {
-    const response = await axios.post(BASE_URL+LOGIN, data);
+    const response = await axios.post(BASE_URL + LOGIN, data);
     return response;
   } catch (error) {
     throw error;

--- a/src/services/auth/authAPI.js
+++ b/src/services/auth/authAPI.js
@@ -78,6 +78,17 @@ export const requestOauthSignUp = async (fields, accessToken) => {
   }
 }
 
+export const requestAccessTokenForOAuth2Login = async () => {
+  try {
+    const response = await axios.get(BASE_URL + OAUTH2_ACCESS_TOKEN, {
+      withCredentials: true
+    });
+    return response;
+  } catch (error) {
+    return error;
+  }
+}
+
 export const requestLogin = async (fields) => {
   let data = {
     email: fields.email.value,

--- a/src/styles/auth.css
+++ b/src/styles/auth.css
@@ -1,43 +1,56 @@
-.sign-up-main { display: flex; flex-direction: column; -webkit-box-pack: center; justify-content: center; -webkit-box-align: center; align-items: center; width: 100%; margin: 24px auto 80px; } 
+.sign-up-main { display: flex; flex-direction: column; -webkit-box-pack: center; justify-content: center; -webkit-box-align: center; align-items: center; width: 100%; margin: 24px auto 80px; }
 
 /** Back 영역 시작**/
-div.back { width: 100%; max-width: 1060px; padding-left: 20px; margin-bottom: 20px; } 
-button.back { font-size: 18px; color: #a4a4a4; background-color: transparent; border: none; display: flex; -webkit-box-align: center; align-items: center; gap: 6px; cursor: pointer; height: 32px; padding: 4px 7px; } 
-span.back, p.back { font-size: 24px; } 
+div.back { width: 100%; max-width: 1060px; padding-left: 20px; margin-bottom: 20px; }
+button.back { font-size: 18px; color: #a4a4a4; background-color: transparent; border: none; display: flex; -webkit-box-align: center; align-items: center; gap: 6px; cursor: pointer; height: 32px; padding: 4px 7px; }
+span.back, p.back { font-size: 24px; }
 /** Back 영역 끝**/
 
 /** 회원가입 Title 영역 시작 **/
-div.title { width: 100%; max-width: 500px; background-color: #ffffff; } 
-h1.title { text-align: center; font-size: 36px; } 
+div.title { width: 100%; max-width: 500px; background-color: #ffffff; }
+h1.title { text-align: center; font-size: 36px; }
 /** 회원가입 Title 영역 끝 **/
 
 /* 회원가입 Form 영역 시작*/
-div.sign-up { width: 100%; max-width: 500px; background-color: #ffffff; } 
-form.sign-up { margin-top: 56px; display: flex; flex-direction: column; gap: 48px; padding: 0 30px; } 
-div.sign-up-input { position: relative; box-sizing: border-box; margin: 0; padding: 0; } 
-div.sign-up-input div { position: relative; box-sizing: border-box; margin: 0; padding: 0; } 
+div.sign-up { width: 100%; max-width: 500px; background-color: #ffffff; }
+form.sign-up { margin-top: 56px; display: flex; flex-direction: column; gap: 48px; padding: 0 30px; }
+div.sign-up-input { position: relative; box-sizing: border-box; margin: 0; padding: 0; }
+div.sign-up-input div { position: relative; box-sizing: border-box; margin: 0; padding: 0; }
 
 /* Label, Input */
-label.input-label { font-size: 18px; text-align: left; } 
-.valid-input { width: 100%; height: 48px; min-height: 48px; outline: none; background-color: transparent; border: none; border-bottom: 2px solid #a4a4a4; font-size: 18px; font-weight: 400; } 
-.valid-input:focus { border-bottom: 2px solid #000000; outline: none; } 
-.valid-input::placeholder { color: #a4a4a4; } 
-.invalid-input { width: 100%; height: 48px; min-height: 48px; outline: none; background-color: transparent; border: none; border-bottom: 2px solid #ff0000; font-size: 18px; font-weight: 400; } 
+label.input-label { font-size: 18px; text-align: left; }
+.valid-input { width: 100%; height: 48px; min-height: 48px; outline: none; background-color: transparent; border: none; border-bottom: 2px solid #a4a4a4; font-size: 18px; font-weight: 400; }
+.valid-input:focus { border-bottom: 2px solid #000000; outline: none; }
+.valid-input::placeholder { color: #a4a4a4; }
+.invalid-input { width: 100%; height: 48px; min-height: 48px; outline: none; background-color: transparent; border: none; border-bottom: 2px solid #ff0000; font-size: 18px; font-weight: 400; }
 
 /* 중복확인, 주소찾기 버튼 */
-.checking-verification, .finding-address { position: absolute; z-index: 1; top: 50%; right: -10px; transform: translateY(-21%); width: fit-content; height: fit-content; min-height: initial; background-color: transparent; padding: 10px; border-radius: 10px; font-size: 18px; border: none; cursor: pointer; color: #000000; } 
-.checking-verification:disabled, .valid-input:disabled { cursor: default; color: #dddddd; } 
-.invalid-caption { font-size: 16px; color: #ff0000; margin: 5px 0 0 0; } 
+.checking-verification, .finding-address { position: absolute; z-index: 1; top: 50%; right: -10px; transform: translateY(-21%); width: fit-content; height: fit-content; min-height: initial; background-color: transparent; padding: 10px; border-radius: 10px; font-size: 18px; border: none; cursor: pointer; color: #000000; }
+.checking-verification:disabled, .valid-input:disabled { cursor: default; color: #dddddd; }
+.invalid-caption { font-size: 16px; color: #ff0000; margin: 5px 0 0 0; }
 
 /* 회원 가입 버튼*/
 /** 회원 가입 Form 영역 끝 **/
 
 
 /* 로그인 */
-.sign-up-link { position: relative; padding-top: 48px; display: flex; flex-direction: column; gap: 30px; justify-content: center; border-top: 1px solid gray; -webkit-box-pack: center } 
-.login-or { font-weight: 600; text-align: left; letter-spacing: 0.025em; font-size: 12px; line-height: 16px; position: absolute; top: -10%; left: 50%; transform: translate(-50%, -50%); background-color: white; padding: 0 12px; color: gray; } 
-.login-bottom-extra-button-div { width: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; gap: 8px; } 
+.sign-up-link { position: relative; padding-top: 48px; display: flex; flex-direction: column; gap: 30px; justify-content: center; border-top: 1px solid gray; -webkit-box-pack: center }
+.login-or { font-weight: 600; text-align: left; letter-spacing: 0.025em; font-size: 12px; line-height: 16px; position: absolute; top: -10%; left: 50%; transform: translate(-50%, -50%); background-color: white; padding: 0 12px; color: gray; }
+.login-bottom-extra-button-div { width: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; gap: 8px; }
+
+.login-buttons-section {display: flex; flex-direction: column; margin: 0 auto 16px auto; max-width: 360px; justify-content: center; gap: 16px; }
+
+.kakao-login-button { width: 360px; display: flex; gap: 8px; justify-content: center; align-items: center; height: 48px; border-radius: 10px; padding: 0; background-color: #fee500; border: 1px solid #fee500; cursor: pointer }
+.google-login-button,.email-login-button { width: 360px; display: flex; gap: 8px; justify-content: center; align-items: center; height: 48px; border-radius: 10px; padding: 0; background-color: #000000; border: 1px solid #000000; cursor: pointer }
+
+span.login-svg { font-size: 18px; color: #000000; display: flex; align-items: inherit; justify-content: inherit; }
+svg.login-svg {user-select: none; width: 1em; height: 1em; display: inline-block; fill: currentColor; flex-shrink: 0; font-size: inherit; }
+
+p.kakao-login-button-text {color: #000000; text-align: left; letter-spacing: 0.01em; font-size: 20px; line-height: 22px; margin-top: 13px; margin-bottom: 13px;}
+p.login-button-text {color: #ffffff; text-align: left; letter-spacing: 0.01em; font-size: 20px; line-height: 22px; margin-top: 13px; margin-bottom: 13px;}
+
+/*.email-login-button { width: 360px; height: 50px; background-color: black; border: none; border-radius: 10px; font-size: 20px; color: white; cursor: pointer; }*/
 
 /* Auth 관련 공통 */
-.auth-button { width: 440px; height: 50px; background-color: black; border: none; border-radius: 10px; font-size: 20px; color: white; cursor: pointer; } 
-.auth-button:disabled { width: 100%; height: 50px; border: none; border-radius: 10px; font-size: 20px; color: rgba(55, 56, 60, 0.16); background-color: rgb(244, 244, 245); cursor: default; } 
+.auth-button { width: 440px; height: 50px; background-color: black; border: none; border-radius: 10px; font-size: 20px; color: white; cursor: pointer; }
+.auth-button:disabled { width: 100%; height: 50px; border: none; border-radius: 10px; font-size: 20px; color: rgba(55, 56, 60, 0.16); background-color: rgb(244, 244, 245); cursor: default; }


### PR DESCRIPTION
#33 

# 소셜 로그인 버튼 추가
- 카카오 로그인
- 구글 로그인
- 필요하다면 네이버도 추가 가능

# 소셜 첫 로그인  → 추가정보 입력
1. 버튼 클릭
2. 카카오/구글 로그인
3. 첫 로그인 시 추가 정보 입력 (닉네임,주소,연락처)
4. 소셜 로그인을 통한 회원가입 완료

# 소셜 로그인
1. 버튼 클릭
2. 카카오/구글 로그인
3. 로그인 후 대기화면으로 이동 ( "/oauth2/login" ) 
4. 대기화면에서 바로 서버에 AccessToken 발급 요청
5. 발급 받으면 메인 화면으로 이동

# Issue
시간이 없어서 Happy Path에 대해서만 간단하게 테스트 해보고 PR 올렸습니다. 이후 추가 테스트 관련 Feature 만들어서 PR 따로 올릴 예정
